### PR TITLE
Fix yet another admin abuse

### DIFF
--- a/stickermanager.tsv
+++ b/stickermanager.tsv
@@ -11,7 +11,7 @@ sticker short	-	telethonpacktopic_by_telethonianbot
 sticker owner	-	10885151
 
 # The number of votes required for a sticker to be approved.
-votes required	6	-
+votes required	8	-
 
 # The vote weight for users who aren't listed.
 default weight	0.5	-


### PR DESCRIPTION
with multiple people now having 3 points and the score being only 6, stickers are instantly accepted if only two of them voted and we don't get a chance to vote no. (see https://t.me/telethonofftopic/548648 )

Increasing the votes required to 8 would give us a chance to fight back