### PR TITLE
paste: Reply to images to tell the users to paste his code/errors to del.dog

### DIFF
--- a/haste.py
+++ b/haste.py
@@ -27,6 +27,9 @@ async def init(bot, modules):
             return
 
         msg = await event.get_reply_message()
+        if msg.photo:
+            await event.respond('Don\'t send photos with your code or errors. Paste the content in del.dog instead.')
+            return
         if len(msg.raw_text or '') < 200:
             sent = await event.respond('Not bothering to paste such a short message.')
             await asyncio.sleep(10)


### PR DESCRIPTION
I've noticed there are too many users who seek help by taking a photo of their code and errors which are most of the time unreadable. This commit will make that users can reply with the paste command to these messages and tell the sender to paste their code on del.dog.