### PR TITLE
Fix text messages sent by the antitag module

### DIFF
--- a/antitag.py
+++ b/antitag.py
@@ -14,11 +14,11 @@ with open(os.path.join(os.path.dirname(__file__), 'admins.txt'), encoding="utf-8
 
 
 PLS_NO_REPLY = (
-    f'Please do not reply to {MURTPITOTC_USERNAME}. They really do not like it.'
+    f'Please do not reply to any of the messages sent by the chat's admins. They really do not like it.'
     ' If you need to quote their messages, use a link, like https://t.me/{}/{}'
 )
 PLS_NO_TAG = (
-    f'Please do not unnecessarily tag {MURTPITOTC_USERNAME}. They really do not like it.'
+    f'Please do not unnecessarily tag chat's admins. They really do not like it.'
     f' If you want to mention them in your message, exclude the "@", like "{MURTPITOTC_USERNAME}"'
 )
 


### PR DESCRIPTION
The first sentence mentions the tagged users and the second sentence mentions all the admins using the term "They".

It's self understanding that it's about all the admins but it's a little weird that the messages starts using the 1st person then it continues with the 3rd person