### PR TITLE
Fixed grammar at one place

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ TOPIC = (
     "This group is for **usage questions about Telethon only**, and "
     "occasionally about semi-related topics like MTProto. Anything that does "
     "not directly involve any of the two does not belong here, and questions "
-    "regarding general Python knowledge or use of any other libraries **does "
+    "regarding general Python knowledge or use of any other libraries **do "
     "not belong here**. Please ask elsewhere."
 )
 


### PR DESCRIPTION
In the `TOPIC` string, changed the following:

```
...questions "
    "regarding general Python knowledge or use of any other libraries **does "
    "not belong here**
```

to

```
...questions "
    "regarding general Python knowledge or use of any other libraries **do "
    "not belong here**
```

**Does** has been changed to **do**. Being a grammar nazi, I did not like this.